### PR TITLE
fix: 공통 응답 객체 수정과 컨트롤러, 예외처리에 대한 적용, base entity 상속 적용

### DIFF
--- a/src/main/java/com/example/dischord/common/BaseEntity.java
+++ b/src/main/java/com/example/dischord/common/BaseEntity.java
@@ -1,19 +1,20 @@
-package com.example.dischord.global.infraStructure;
+package com.example.dischord.common;
 
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import lombok.Data;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
-@Data
+
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
+@Getter
 public class BaseEntity {
 
     @CreatedDate
@@ -23,4 +24,7 @@ public class BaseEntity {
     @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/example/dischord/global/exception/DuplicateException.java
+++ b/src/main/java/com/example/dischord/global/exception/DuplicateException.java
@@ -1,0 +1,15 @@
+package com.example.dischord.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class DuplicateException extends RuntimeException {
+
+    private final int code;
+    private final String message;
+
+    public DuplicateException(final ExceptionCode exceptionCode) {
+        this.code = exceptionCode.getCode();
+        this.message = exceptionCode.getMessage();
+    }
+}

--- a/src/main/java/com/example/dischord/global/exception/ExceptionCode.java
+++ b/src/main/java/com/example/dischord/global/exception/ExceptionCode.java
@@ -8,13 +8,14 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum ExceptionCode {
 
+    INVALID_PASSWORD(401, "이메일이나 비밀번호가 일치하지 않습니다."),
+    INVALID_EMAIL(401, "이메일이나 비밀번호가 일치하지 않습니다."),
+
     NOT_FOUND_USER_ID(404, "해당하는 유저가 존재하지 않습니다."),
 
 
-    DUPLICATED_USER_EMAIL(409, "이미 가입된 이메일입니다."),
+    DUPLICATED_USER_EMAIL(409, "이미 가입된 이메일입니다.");
 
-    INVALID_PASSWORD(401, "이메일이나 비밀번호가 일치하지 않습니다."),
-    INVALID_EMAIL(401, "이메일이나 비밀번호가 일치하지 않습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/example/dischord/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/dischord/global/exception/GlobalExceptionHandler.java
@@ -21,7 +21,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
 
-    @ExceptionHandler(BadRequestException.class)
+    @ExceptionHandler(DuplicateException.class)
     public ResponseEntity<ExceptionResponse> handleDuplicateException(final DuplicateException e) {
         log.warn(e.getMessage(), e);
 

--- a/src/main/java/com/example/dischord/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/dischord/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.example.dischord.global.exception;
 
+import com.example.dischord.global.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -10,8 +11,18 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @Slf4j
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
+
     @ExceptionHandler(BadRequestException.class)
-    public ResponseEntity<ExceptionResponse> handleBadRequestException(final BadRequestException e) {
+    public ApiResponse<ExceptionResponse> handleBadRequestException(final BadRequestException e) {
+
+        log.warn(e.getMessage(), e);
+
+        return ApiResponse.createError(e.getCode(), e.getMessage());
+    }
+
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ExceptionResponse> handleDuplicateException(final DuplicateException e) {
         log.warn(e.getMessage(), e);
 
         return ResponseEntity.badRequest()

--- a/src/main/java/com/example/dischord/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/dischord/global/exception/GlobalExceptionHandler.java
@@ -17,16 +17,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         log.warn(e.getMessage(), e);
 
-        return ApiResponse.createError(e.getCode(), e.getMessage());
+        return ApiResponse.error(e.getCode(), e.getMessage());
     }
 
 
-    @ExceptionHandler(BadRequestException.class)
-    public ResponseEntity<ExceptionResponse> handleDuplicateException(final DuplicateException e) {
+    @ExceptionHandler(DuplicateException.class)
+    public ApiResponse<ExceptionResponse> handleDuplicateException(final DuplicateException e) {
+
         log.warn(e.getMessage(), e);
 
-        return ResponseEntity.badRequest()
-                .body(new ExceptionResponse(e.getCode(), e.getMessage()));
+        return ApiResponse.error(e.getCode(), e.getMessage());
     }
 
 

--- a/src/main/java/com/example/dischord/global/infraStructure/BaseEntity.java
+++ b/src/main/java/com/example/dischord/global/infraStructure/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.example.dischord.global.infraStructure;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Data;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Data
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "signup_at")
+    private LocalDateTime signupAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/dischord/global/response/ApiResponse.java
+++ b/src/main/java/com/example/dischord/global/response/ApiResponse.java
@@ -27,11 +27,11 @@ public class ApiResponse<T> {
         return new ApiResponse<>(200, null, data);
     }
 
-    public static ApiResponse<?> okWithNoContent() {
+    public static ApiResponse<?> ok() {
         return new ApiResponse<>(200, null, null);
     }
 
-    public static ApiResponse<ExceptionResponse> createError(int errorCode, String message) {
+    public static ApiResponse<ExceptionResponse> error(int errorCode, String message) {
         return new ApiResponse<>(errorCode, message, null);
     }
 

--- a/src/main/java/com/example/dischord/global/response/ApiResponse.java
+++ b/src/main/java/com/example/dischord/global/response/ApiResponse.java
@@ -1,14 +1,40 @@
 package com.example.dischord.global.response;
 
+import com.example.dischord.global.exception.ExceptionResponse;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+@NoArgsConstructor
 @Getter
 @Setter
 public class ApiResponse<T> {
+
+
     private int code;
     private String message;
     private T data;
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(200, null, data);
+    }
+
+    public static ApiResponse<?> okWithNoContent() {
+        return new ApiResponse<>(200, null, null);
+    }
+
+    public static ApiResponse<ExceptionResponse> createError(int errorCode, String message) {
+        return new ApiResponse<>(errorCode, message, null);
+    }
+
 
     public ApiResponse(int code, String message, T data) {
         this.code = code;

--- a/src/main/java/com/example/dischord/user/controller/UserApiController.java
+++ b/src/main/java/com/example/dischord/user/controller/UserApiController.java
@@ -6,8 +6,6 @@ import com.example.dischord.user.requestDto.UserSignupRequestDto;
 import com.example.dischord.user.responseDto.UserResponseDto;
 import com.example.dischord.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -30,6 +28,14 @@ public class UserApiController {
         UserResponseDto responseDto = userService.getUser(userId);
 
         return ApiResponse.ok(responseDto);
+    }
+
+    @DeleteMapping("/api/user/{userId}")
+    public ApiResponse<?> signOutUser(@PathVariable Long userId) {
+
+        userService.deleteUser(userId);
+
+        return ApiResponse.ok();
     }
 
 

--- a/src/main/java/com/example/dischord/user/controller/UserApiController.java
+++ b/src/main/java/com/example/dischord/user/controller/UserApiController.java
@@ -17,19 +17,19 @@ public class UserApiController {
     private final UserService userService;
 
     @PostMapping("/api/user")
-    public ResponseEntity<ApiResponse<?>> signupUser(@RequestBody UserSignupRequestDto requestDto) {
+    public ApiResponse<UserResponseDto> signupUser(@RequestBody UserSignupRequestDto requestDto) {
 
         UserResponseDto responseDto = userService.signupUser(requestDto);
 
-        return ResponseEntity.ok().body(new ApiResponse<>(201, "가입 성공",responseDto));
+        return ApiResponse.ok(responseDto);
     }
 
     @GetMapping("/api/user/{userId}")
-    public ResponseEntity<ApiResponse<?>> getUser(@PathVariable Long userId) {
+    public ApiResponse<UserResponseDto> getUser(@PathVariable Long userId) {
 
         UserResponseDto responseDto = userService.getUser(userId);
 
-        return ResponseEntity.ok().body(new ApiResponse<>(200, "회원 정보 조회 성공",responseDto));
+        return ApiResponse.ok(responseDto);
     }
 
 

--- a/src/main/java/com/example/dischord/user/entity/User.java
+++ b/src/main/java/com/example/dischord/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.example.dischord.user.entity;
 
+import com.example.dischord.global.infraStructure.BaseEntity;
 import com.example.dischord.user.type.UserStateType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -15,9 +16,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 @Table(name = "users")
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,16 +33,10 @@ public class User {
     @Column(nullable = false)
     private String nickname;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserStateType userState;
 
-    @CreatedDate
-    @Column(name = "signup_at")
-    private LocalDateTime signupAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     @Builder
     public User(String email, String password, String nickname) {

--- a/src/main/java/com/example/dischord/user/entity/User.java
+++ b/src/main/java/com/example/dischord/user/entity/User.java
@@ -1,20 +1,17 @@
 package com.example.dischord.user.entity;
 
-import com.example.dischord.global.infraStructure.BaseEntity;
+import com.example.dischord.common.BaseEntity;
 import com.example.dischord.user.type.UserStateType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
+import org.hibernate.annotations.SQLDelete;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@SQLDelete(sql = "UPDATE users SET deleted_at = CURRENT_TIMESTAMP WHERE user_id=?")
 @Entity
 @Table(name = "users")
 public class User extends BaseEntity {

--- a/src/main/java/com/example/dischord/user/repository/UserRepository.java
+++ b/src/main/java/com/example/dischord/user/repository/UserRepository.java
@@ -3,10 +3,17 @@ package com.example.dischord.user.repository;
 
 import com.example.dischord.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
+
+    @Query("SELECT u FROM User u WHERE u.id = :id AND u.deletedAt IS NULL")
+    Optional<User> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/com/example/dischord/user/service/UserService.java
+++ b/src/main/java/com/example/dischord/user/service/UserService.java
@@ -2,12 +2,11 @@ package com.example.dischord.user.service;
 
 
 import com.example.dischord.global.exception.BadRequestException;
-import com.example.dischord.global.exception.ExceptionCode;
+import com.example.dischord.global.exception.DuplicateException;
 import com.example.dischord.user.entity.User;
 import com.example.dischord.user.repository.UserRepository;
 import com.example.dischord.user.requestDto.UserSignupRequestDto;
 import com.example.dischord.user.responseDto.UserResponseDto;
-import com.example.dischord.user.responseDto.UserSignupResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -36,7 +35,7 @@ public class UserService {
 
     private void checkDuplicatedEmail(final String email) {
         if (userRepository.existsByEmail(email)) {
-            throw new BadRequestException(DUPLICATED_USER_EMAIL);
+            throw new DuplicateException(DUPLICATED_USER_EMAIL);
         }
     }
 

--- a/src/main/java/com/example/dischord/user/service/UserService.java
+++ b/src/main/java/com/example/dischord/user/service/UserService.java
@@ -8,6 +8,7 @@ import com.example.dischord.user.repository.UserRepository;
 import com.example.dischord.user.requestDto.UserSignupRequestDto;
 import com.example.dischord.user.responseDto.UserResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -41,9 +42,17 @@ public class UserService {
 
     public UserResponseDto getUser(Long userId) {
 
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_USER_ID));
 
         return UserResponseDto.from(user);
+    }
+
+    public void deleteUser(Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_USER_ID));
+
+        userRepository.delete(user);
     }
 }


### PR DESCRIPTION
1. 공통 응답 객체 적용 방식 수정
컨트롤러와 전역 예외처리 코드의 ResponseEntity<ApiResponse<?>>
부분을 ApiResponse<response> 와 같은 타입으로 수정했습니다.

2. user entity 수정
- 생성일, 수정일에 대한 컬럼을 BaseEntity를 생성하여 상속 받도록 하였습니다.
- private UserStateType userState; 컬럼에 enum.string 어노테이션을 추가하였습니다.

3. 회원가입시 이메일 중복확인 메서드의 에러 반환 수정 
duplicateException을 추가 하여 기존의 badRequestException과 구분을 해주었습니다.

