### PR TITLE
GitHub Actions를 통한 서버 배포 기능 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,64 @@
+name: Java CI with Gradle
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Set application.yml file
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: src/main/resources/application.yml
+        env:
+          spring.datasource.url: ${{ secrets.RDS_URL }}
+          spring.datasource.username: ${{ secrets.RDS_USERNAME }}
+          spring.datasource.password: ${{ secrets.RDS_PASSWORD }}
+      - name: Set docker-compose.yml file
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: docker-compose.yml
+        env:
+          services.backend.environment.SPRING_DATASOURCE_URL: ${{ secrets.RDS_URL }}
+          services.backend.environment.SPRING_DATASOURCE_USERNAME: ${{ secrets.RDS_USERNAME }}
+          services.backend.environment.SPRING_DATASOURCE_PASSWORD: ${{ secrets.RDS_PASSWORD }}
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build -x test
+      - name: Docker build
+        run: |
+          docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} -p ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker-compose build
+          docker tag hunnit/dischord hunnit/dischord:${GITHUB_SHA::6}
+          docker push hunnit/dischord:${GITHUB_SHA::6}
+      - name: Deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ubuntu
+          key: ${{ secrets.KEY }}
+          envs: GITHUB_SHA
+          debug: true
+          script: |
+            docker pull hunnit/dischord:${GITHUB_SHA::6}
+            docker tag hunnit/dischord:${GITHUB_SHA::6} dischord
+            docker stop server
+            docker rm -f server
+            docker run -d --name server -p 8080:8080 dischord

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,4 @@ out/
 .vscode/
 
 ### config ###
-*.yml
 *.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+#base-image
+FROM openjdk:17
+# 2. Set the working directory
+WORKDIR /app
+
+# 3. Copy the jar file into the container
+COPY build/libs/*.jar app.jar
+
+# 4. Expose the port the app runs on
+EXPOSE 8080
+
+# 5. Run the jar file
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  backend:
+    platform: linux/amd64
+    build:
+      context: .
+      dockerfile: Dockerfile
+    working_dir: /app
+    image: hunnit/dischord
+    environment:
+      SPRING_DATASOURCE_URL: ${RDS_URL}
+      SPRING_DATASOURCE_USERNAME: ${RDS_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${RDS_PASSWORD}
+    ports:
+      - "8080:8080"
+    restart: always

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${RDS_URL}
+    username: ${RDS_USERNAME}
+    password: ${RDS_PASSWORD}
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+        highlight_sql: true
+        generate_statistics: true
+    hibernate:
+      ddl-auto: update


### PR DESCRIPTION
1. .gitignore 파일에서 .yml을 제거하였습니다.

2. RDS, Docker, EC2에 대한 민감한 정보는 secrets에 저장해두었고, 이를 GitHub 액션에서 불러와서 사용합니다.
- Dockerfile, docker-compose.yml, application.yml, .github/workflows/main.yml을 추가했습니다.
